### PR TITLE
Fix: social art path correction and ensure the images are included in the build

### DIFF
--- a/plugins/social.cjs
+++ b/plugins/social.cjs
@@ -99,8 +99,8 @@ const pluginSocial = () => ({
         hash,
         social: {
           image: {
-            absolutePath,
             height,
+            publicPath,
             width,
           },
         },
@@ -130,10 +130,13 @@ const pluginSocial = () => ({
         width,
       });
 
-      mkdirSync(dirname(absolutePath), {
+      const baseDistPath = path.resolve(process.cwd(), './dist');
+      const distPath = path.resolve(baseDistPath, `.${publicPath}`);
+
+      mkdirSync(dirname(distPath), {
         recursive: true,
       });
-      writeFileSync(absolutePath, artRaster);
+      writeFileSync(distPath, artRaster);
     }
   },
 });

--- a/snowpack.config.cjs
+++ b/snowpack.config.cjs
@@ -53,8 +53,8 @@ const config = {
   },
 
   plugins: [
-    path.resolve(cwd, './plugins/fela.cjs'),
     path.resolve(cwd, './plugins/social.cjs'),
+    path.resolve(cwd, './plugins/fela.cjs'),
   ],
 };
 

--- a/src/lib/content/meta.ts
+++ b/src/lib/content/meta.ts
@@ -61,16 +61,16 @@ const getPageSocialMetadata = (
   hashSeed:  any,
   imageType: RasterType = RasterType.PNG
 ): PageSocial => {
-  const publicBasePath = importURL.replace(
+  const imagesBasePath = importURL.replace(
     /^file:(\/\/)?(\/.*?)\/src\/.*$/,
-    '$2/public'
+    '$2/images'
   );
   const hash = socialImageNameHasher.hash(hashSeed);
   const absolutePath = path.resolve(
-    publicBasePath,
+    imagesBasePath,
     `${hash}.${imageType}`
   );
-  const publicPath = absolutePath.replace(/^.*?\/public\//, '/');
+  const publicPath = absolutePath.replace(/^.*?\/images\//, '/images/');
 
   return {
     image: {


### PR DESCRIPTION
Writes directly to dist directory. I strongly suspect this is a bandaid and it's really not at all clear to me why the files aren't moved from staging to dist with the previous code. Anyway it's all the more complicated to test this because social images require a public fully qualified URL to even validate