### PR TITLE
Fix: set background color on html, body

### DIFF
--- a/src/lib/styles/global.ts
+++ b/src/lib/styles/global.ts
@@ -90,7 +90,7 @@ export const criticalStyles = cleanWhitespace(`
 
   ${jsToCSS([ 'html', 'body' ], {
     ...theme.document,
-  }
+  })}
 
   ${jsToCSS([ 'body' ], {
     ...theme.prose,


### PR DESCRIPTION
Ensures default background color doesn’t bleed on Safari. Edited on iPhone 🤞