### PR TITLE
Fix: code block scroll shadows on Safari

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -23,26 +23,28 @@ const ContentContainer = styled('pre', {
 // ].join(', ')})`;
 
 const BaseInnerContainer = styled(FullBleedScrollableOverflow, {
-  backgroundAttachment: 'local',
-  backgroundImage: `linear-gradient(${[
-    'to left',
-    'rgba(255,255,255,1)',
-    'rgba(255,255,255,1) 5rem',
-    'rgba(255,255,255,0) 6rem',
-  ].join(',')})`,
-  backgroundPosition: 'calc(100% + 4rem) 0',
-  backgroundRepeat:   'no-repeat',
-  backgroundSize:     '6rem',
+  // backgroundAttachment: 'local',
+  // backgroundImage: `linear-gradient(${[
+  //   'to left',
+  //   'rgba(255,255,255,1)',
+  //   'rgba(255,255,255,1) 5rem',
+  //   'rgba(255,255,255,0) 6rem',
+  //   'rgba(255,255,255,0) 12rem',
+  // ].join(',')})`,
+  // backgroundPosition: 'calc(100% + 4rem) 0',
+  // backgroundRepeat:   'no-repeat',
+  // backgroundSize:     '12rem 100%',
   paddingLeft:        'clamp(1.25em, 3.5vw, 3em)',
 
   nested: {
     [theme.darkMode]: {
-      backgroundImage: `linear-gradient(${[
-        'to left',
-        'rgba(0,0,0,1)',
-        'rgba(0,0,0,1) 5rem',
-        'rgba(0,0,0,0) 6rem',
-      ].join(',')})`,
+      // backgroundImage: `linear-gradient(${[
+      //   'to left',
+      //   'rgba(0,0,0,1)',
+      //   'rgba(0,0,0,1) 5rem',
+      //   'rgba(0,0,0,0) 6rem',
+      //   'rgba(0,0,0,0) 12rem',
+      // ].join(',')})`,
     },
   },
   // maskImage,
@@ -51,12 +53,12 @@ const BaseInnerContainer = styled(FullBleedScrollableOverflow, {
 
 const InnerContainer = (props: ComponentProps<typeof BaseInnerContainer>) => (
   <BaseInnerContainer
-    // shadow={ {
-    //   darkMask:    [ 0, 0, 0, 1 ],
-    //   darkScroll:  [ 0, 164, 255, 0.75 ],
-    //   lightMask:   [ 255, 255, 255, 1 ],
-    //   lightScroll: [ 124, 128, 131, 0.75 ],
-    // } }
+    shadow={ {
+      darkMask:    [ 0, 0, 0, 1 ],
+      darkScroll:  [ 0, 164, 255, 0.75 ],
+      lightMask:   [ 255, 255, 255, 1 ],
+      lightScroll: [ 124, 128, 131, 0.75 ],
+    } }
     { ...props }
   />
 );
@@ -64,23 +66,23 @@ const InnerContainer = (props: ComponentProps<typeof BaseInnerContainer>) => (
 const OuterContainer = styled(FullBleedContainer, {
   ...theme.pre,
 
-  backgroundImage: `linear-gradient(${[
-    'to left',
-    'rgba(124, 128, 131, 0.75)',
-    'rgba(124, 128, 131, 0.75) 0.5px',
-    'rgba(124, 128, 131, 0)    5px',
-  ].join(',')})`,
+  // backgroundImage: `linear-gradient(${[
+  //   'to left',
+  //   'rgba(124, 128, 131, 0.75)',
+  //   'rgba(124, 128, 131, 0.75) 0.5px',
+  //   'rgba(124, 128, 131, 0)    5px',
+  // ].join(',')})`,
 
   nested: {
     [theme.darkMode]: {
       ...theme[theme.darkMode].pre,
 
-      backgroundImage: `linear-gradient(${[
-        'to left',
-        'rgba(230, 179, 213, 0.75)',
-        'rgba(230, 179, 213, 0.75) 0.5px',
-        'rgba(230, 179, 213, 0)    5px',
-      ].join(',')})`,
+      // backgroundImage: `linear-gradient(${[
+      //   'to left',
+      //   'rgba(230, 179, 213, 0.75)',
+      //   'rgba(230, 179, 213, 0.75) 0.5px',
+      //   'rgba(230, 179, 213, 0)    5px',
+      // ].join(',')})`,
     },
 
     '& code': {

--- a/src/components/Favicons.tsx
+++ b/src/components/Favicons.tsx
@@ -53,9 +53,5 @@ export const Favicons = () => (
       name="msapplication-config"
       content="/favicons/browserconfig.xml"
     />
-    <meta
-      name="theme-color"
-      content="#ffffff"
-    />
   </>
 );

--- a/src/components/FullBleed/FullBleedScrollableOverflow.tsx
+++ b/src/components/FullBleed/FullBleedScrollableOverflow.tsx
@@ -1,4 +1,5 @@
 import {
+  renderer,
   styled,
   theme,
 } from '@/lib/styles';
@@ -36,6 +37,28 @@ const transparent = ([ r, g, b ]: RGBA) => (
   `rgba(${[ r, g, b, 0].join(',')})`
 );
 
+const backgroundSizes = [
+  '12rem 100%',
+  'auto',
+];
+
+const backgroundSize = backgroundSizes.join(', ');
+
+const backgroundSizeAlt = backgroundSizes.map((size) => (
+  size.replace('100%', '100.1%')
+)).join(', ');
+
+const safariScrollShadowFix = renderer.renderKeyframe(() => ({
+  '0%': {
+    backgroundSize,
+  },
+  '100%': {
+    backgroundSize: backgroundSizeAlt,
+  },
+}), {});
+
+const shadowSizePx = '5px';
+
 const shadowImages = (scroll?: RGBA, mask?: RGBA) => (
   scroll != null && mask != null
     ? {
@@ -43,13 +66,14 @@ const shadowImages = (scroll?: RGBA, mask?: RGBA) => (
           `linear-gradient(${[
             'to left',
             `rgba(${mask.join(',')})`,
-            `${transparent(mask)} 2rem`,
+            `rgba(${mask.join(',')}) calc(11rem + ${shadowSizePx})`,
+            `${transparent(mask)} 12rem`,
           ].join(', ')})`,
           `linear-gradient(${[
             'to left',
             `rgba(${scroll.join(',')})`,
             `rgba(${scroll.join(',')}) 0.5px`,
-            `${transparent(scroll)} 5px`,
+            `${transparent(scroll)} ${shadowSizePx}`,
           ].join(', ')})`,
         ].join(', '),
       }
@@ -75,7 +99,7 @@ const shadowStyles = (shadow?: FullBleedScrollableOverflowShadowMask) => {
     dark:  null,
     light: null,
   };
-}
+};
 
 export const FullBleedScrollableOverflow = styled(
   BaseFullBleedScrollableOverflow,
@@ -94,12 +118,14 @@ export const FullBleedScrollableOverflow = styled(
     return {
       ...light,
 
+      // '@keyframes': {},
+
       backgroundAttachment: 'local, scroll',
-      backgroundPosition:   '100% 0, 0 0',
+      backgroundPosition:   'calc(100% + 11rem) 0, 0 0',
       backgroundRepeat:     'no-repeat',
-      backgroundSize:       '1rem, auto',
-      paddingRight:         theme.mainGridSidePaddingRem,
-      overflowX:            'auto',
+      backgroundSize,
+      paddingRight: theme.mainGridSidePaddingRem,
+      overflowX:    'auto',
 
       nested: {
         ...darkStyles,
@@ -107,7 +133,27 @@ export const FullBleedScrollableOverflow = styled(
         '& > *': {
           gridColumn: '3 / -1',
         },
+
+        '@media not all and (min-resolution: .001dpcm)': {
+          nested: {
+            '@supports (-webkit-appearance: none)': {
+              animationName:           safariScrollShadowFix,
+              animationDuration:       '1000s',
+              animationIterationCount: 'infinite',
+            },
+          },
+        },
+
+        '@media (hover: hover)': {
+          animationPlayState: 'paused',
+
+          nested: {
+            '&:active, &:focus, &:hover': {
+              animationPlayState: 'running',
+            },
+          },
+        },
       },
-    };
+    } as const;
   }
 );


### PR DESCRIPTION
This has been bugging me for ages. This does fix the scroll shadow when reaching the end of the scrollable area, unfortunately it doesn’t fix overscroll. Probably could do something with a pseudo-element but this is good enough for now.