### PR TITLE
feat(blog,projects): restore some of the content previously removed

### DIFF
--- a/src/components/Projects/Projects.tsx
+++ b/src/components/Projects/Projects.tsx
@@ -79,14 +79,16 @@ export const Projects = ({
 			<ProjectsArt {...meta} renderType={'post'} />
 			<h1>Projects</h1>
 
-			<ProjectsCurrent>
-				<h2>Current</h2>
-				<ProjectSet>
-					{current.map((project) => (
-						<Project project={project} />
-					))}
-				</ProjectSet>
-			</ProjectsCurrent>
+			{current.length > 0 ? (
+				<ProjectsCurrent>
+					<h2>Current</h2>
+					<ProjectSet>
+						{current.map((project) => (
+							<Project project={project} />
+						))}
+					</ProjectSet>
+				</ProjectsCurrent>
+			) : null}
 
 			<ProjectsTwoUp {...props}>
 				<div>

--- a/src/components/Site/SiteHeader.tsx
+++ b/src/components/Site/SiteHeader.tsx
@@ -1,5 +1,5 @@
 import type { ComponentChildren } from 'preact';
-import { BLOG_PATH, RESUME_ISOLATION, RESUME_PATH } from '../../data/site.js';
+import { BLOG_PATH, PROJECTS_PATH, RESUME_ISOLATION } from '../../data/site.js';
 import type { PageMetadata } from '../../lib/content/meta.js';
 import { styled, theme } from '../../lib/styles/index.js';
 import { DevilsAlbatross } from '../DevilsAlbatross.js';
@@ -148,8 +148,8 @@ export const SiteHeader = (props: SiteHeaderProps): ComponentChildren => {
 		},
 
 		{
-			label: 'Hire me',
-			location: RESUME_PATH,
+			label: 'Projects',
+			location: PROJECTS_PATH,
 		},
 
 		{

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -10,3 +10,5 @@ export const RESUME_PATH = (() => {
 
 	return `${RESUME_BASE_PATH}#resume`;
 })();
+
+export const PROJECTS_PATH = '/projects/';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -46,6 +46,7 @@ export default definePage(IndexPage, {
 				topics: [Topic.ART, Topic.TECHNOLOGY, Topic.LEMON],
 
 				description,
+				redirect: '/blog/',
 			},
 		});
 	},

--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -1,12 +1,25 @@
 import { definePage } from 'microsite/page';
 import { Head } from '../../components/Head.js';
-import { RESUME_BASE_PATH } from '../../data/site.js';
+import { Main } from '../../components/Main.js';
+import { Projects } from '../../components/Projects/Projects.js';
+import { projects } from '../../data/projects.js';
 import type { PageMetadata } from '../../lib/content/index.js';
-import { getPageMetadata, PageMetadataType } from '../../lib/content/index.js';
+import {
+	getPageMetadata,
+	PageMetadataType,
+	Topic,
+} from '../../lib/content/index.js';
 
 interface ProjectPageProps extends PageMetadata {}
 
-const ProjectPage = (props: ProjectPageProps) => <Head meta={props} />;
+const ProjectPage = (props: ProjectPageProps) => (
+	<>
+		<Head meta={props} />
+		<Main meta={props}>
+			<Projects meta={props} projects={projects} />
+		</Main>
+	</>
+);
 
 export default definePage(ProjectPage, {
 	getStaticProps({ path }) {
@@ -24,8 +37,8 @@ export default definePage(ProjectPage, {
 			props: {
 				...meta,
 
+				topics: [Topic.ART, Topic.TECHNOLOGY, Topic.LEMON],
 				description,
-				redirect: `${RESUME_BASE_PATH}#projects`,
 				title,
 			},
 		});


### PR DESCRIPTION
For now, the nav links Projects rather than Resume, since I've let the web version lapse for a while.